### PR TITLE
Get recipes with search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 /config/master.key
 /config/application.yml
 /coverage
+/spec/fixtures

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::RecipesController < ApplicationController
+  def index
+    recipes = RecipeFacade.new.get_recipes(params[:q])
+    render json: RecipeSerializer.new(recipes)
+  end
+end

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,6 +1,12 @@
 class Api::V1::RecipesController < ApplicationController
   def index
-    recipes = RecipeFacade.new.get_recipes(params[:q])
-    render json: RecipeSerializer.new(recipes)
+    if params[:q]
+      recipes = RecipeFacade.new.get_recipes(params[:q])
+      render json: RecipeSerializer.new(recipes)
+    else
+      country = CountryFacade.random_country
+      recipes = RecipeFacade.new.get_recipes(country)
+      render json: RecipeSerializer.new(recipes)
+    end
   end
 end

--- a/app/facades/country_facade.rb
+++ b/app/facades/country_facade.rb
@@ -1,0 +1,7 @@
+class CountryFacade
+  def self.random_country
+    country = CountryService.new.all_countries
+    num = rand(1..country.count)
+    country[num][:name][:common]
+  end
+end

--- a/app/facades/recipe_facade.rb
+++ b/app/facades/recipe_facade.rb
@@ -1,0 +1,9 @@
+class RecipeFacade
+
+  def get_recipes(country)
+    recipes = RecipeService.new.recipes(country)
+    recipes[:hits].map do |recipe|
+      Recipe.new(recipe, country)
+    end
+  end
+end

--- a/app/poros/recipe.rb
+++ b/app/poros/recipe.rb
@@ -1,0 +1,10 @@
+class Recipe
+  attr_reader :title, :image, :url, :country, :id
+  def initialize(recipe_data, country)
+    @title = recipe_data[:recipe][:label]
+    @image = recipe_data[:recipe][:image]
+    @url = recipe_data[:recipe][:url]
+    @country = country
+    @id = "null"
+  end
+end

--- a/app/serializers/recipe_serializer.rb
+++ b/app/serializers/recipe_serializer.rb
@@ -1,0 +1,4 @@
+class RecipeSerializer
+  include JSONAPI::Serializer
+  attributes :title, :image, :url, :country
+end

--- a/app/services/country_service.rb
+++ b/app/services/country_service.rb
@@ -1,0 +1,15 @@
+class CountryService
+
+  def all_countries
+    get_url("/v3.1/all")
+  end
+
+  def get_url(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new(url: "https://restcountries.com/")
+  end
+end

--- a/app/services/recipe_service.rb
+++ b/app/services/recipe_service.rb
@@ -1,0 +1,18 @@
+class RecipeService
+  def recipes(search)
+    get_url("/api/recipes/v2?type=public&q=#{search}")
+  end
+
+  def get_url(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new(url: "https://api.edamam.com/") do |f|
+      f.headers["Content-Type"] = "application/json"
+      f.params["app_id"] = ENV["EDAMAM_ID"]
+      f.params["app_key"] = ENV["EDAMAM_KEY"]
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      resources :recipes, only: [:index]
+    end
+  end
 end

--- a/spec/facades/country_facade_spec.rb
+++ b/spec/facades/country_facade_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe CountryFacade, :vcr do
+  describe "can generate a random country" do
+    it "random_country" do
+      country = CountryFacade.random_country
+
+      expect(country).to be_a(String)
+      expect(country).to_not be_a(Hash)
+      expect(country).to_not be_a(Array)
+      expect(country).to_not be_empty
+    end
+  end
+end

--- a/spec/facades/recipe_facade_spec.rb
+++ b/spec/facades/recipe_facade_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe RecipeFacade, :vcr do
+  describe "can create a Recipe poro" do
+    it "get_recipes(country)" do
+      recipes = RecipeFacade.new.get_recipes("japan")
+
+      expect(recipes).to be_an(Array)
+      expect(recipes.count).to eq(20)
+      expect(recipes[0]).to be_a(Recipe)
+      expect(recipes[0].title).to be_a(String)
+      expect(recipes[0].image).to be_a(String)
+      expect(recipes[0].url).to be_a(String)
+      expect(recipes[0].country).to be_a(String)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,7 +74,6 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
-  config.filter_sensitive_data('tmdb_key') { ENV['tmdb_key'] }
-  config.default_cassette_options = { re_record_interval: 7.days }
+  config.default_cassette_options = { record: :new_episodes }
   config.configure_rspec_metadata!
 end

--- a/spec/requests/api/v1/recipes/get_request_spec.rb
+++ b/spec/requests/api/v1/recipes/get_request_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/recipes", :vcr do
+  describe "happy path" do
+    it "returns a list of recipes" do
+      get("/api/v1/recipes", headers: {"CONTENT_TYPE" => "application/json"}, params: {q: "japan"})
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      recipes = JSON.parse(response.body, symbolize_names: true)
+
+      expect(recipes[:data].count).to eq(20)
+      expect(recipes).to be_a(Hash)
+      expect(recipes).to have_key(:data)
+      expect(recipes[:data]).to be_an(Array)
+      expect(recipes[:data][0]).to have_key(:id)
+      expect(recipes[:data][0][:id]).to be_a(String)
+      expect(recipes[:data][0]).to have_key(:type)
+      expect(recipes[:data][0][:type]).to be_a(String)
+      expect(recipes[:data][0]).to have_key(:attributes)
+      expect(recipes[:data][0][:attributes]).to be_a(Hash)
+      expect(recipes[:data][0][:attributes]).to have_key(:title)
+      expect(recipes[:data][0][:attributes][:title]).to be_a(String)
+      expect(recipes[:data][0][:attributes]).to have_key(:image)
+      expect(recipes[:data][0][:attributes][:image]).to be_a(String)
+      expect(recipes[:data][0][:attributes]).to have_key(:url)
+      expect(recipes[:data][0][:attributes][:url]).to be_a(String)
+      expect(recipes[:data][0][:attributes]).to have_key(:country)
+      expect(recipes[:data][0][:attributes][:country]).to be_a(String)
+
+      expect(recipes[:data][0]).to_not have_key(:ingredients)
+      expect(recipes[:data][0]).to_not have_key(:calories)
+      expect(recipes[:data][0]).to_not have_key(:dietLabels)
+      expect(recipes[:data][0]).to_not have_key(:healthLabels)
+      expect(recipes[:data][0]).to_not have_key(:cautions)
+      expect(recipes[:data][0]).to_not have_key(:cuisineType)
+    end
+  end
+end

--- a/spec/requests/api/v1/recipes/get_request_spec.rb
+++ b/spec/requests/api/v1/recipes/get_request_spec.rb
@@ -36,5 +36,57 @@ RSpec.describe "GET /api/v1/recipes", :vcr do
       expect(recipes[:data][0]).to_not have_key(:cautions)
       expect(recipes[:data][0]).to_not have_key(:cuisineType)
     end
+
+    it "sad path: selects a random country if no input is given" do
+      get "/api/v1/recipes", headers: {"CONTENT_TYPE" => "application/json"}
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      recipes = JSON.parse(response.body, symbolize_names: true)
+
+      expect(recipes).to be_a(Hash)
+      expect(recipes).to have_key(:data)
+      expect(recipes[:data]).to be_an(Array)
+      expect(recipes[:data][0]).to have_key(:id)
+      expect(recipes[:data][0][:id]).to be_a(String)
+      expect(recipes[:data][0]).to have_key(:type)
+      expect(recipes[:data][0][:type]).to be_a(String)
+      expect(recipes[:data][0]).to have_key(:attributes)
+      expect(recipes[:data][0][:attributes]).to be_a(Hash)
+      expect(recipes[:data][0][:attributes]).to have_key(:title)
+      expect(recipes[:data][0][:attributes][:title]).to be_a(String)
+      expect(recipes[:data][0][:attributes]).to have_key(:image)
+      expect(recipes[:data][0][:attributes][:image]).to be_a(String)
+      expect(recipes[:data][0][:attributes]).to have_key(:url)
+      expect(recipes[:data][0][:attributes][:url]).to be_a(String)
+      expect(recipes[:data][0][:attributes]).to have_key(:country)
+      expect(recipes[:data][0][:attributes][:country]).to be_a(String)
+
+      expect(recipes[:data][0]).to_not have_key(:ingredients)
+      expect(recipes[:data][0]).to_not have_key(:calories)
+      expect(recipes[:data][0]).to_not have_key(:dietLabels)
+      expect(recipes[:data][0]).to_not have_key(:healthLabels)
+      expect(recipes[:data][0]).to_not have_key(:cautions)
+      expect(recipes[:data][0]).to_not have_key(:cuisineType)
+    end
+
+    it "sad path: returns empty array if no recipes are found" do
+      get "/api/v1/recipes", headers: {"CONTENT_TYPE" => "application/json"}, params: {q: "asdf"}
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      recipes = JSON.parse(response.body, symbolize_names: true)
+
+      expect(recipes).to be_a(Hash)
+      expect(recipes).to have_key(:data)
+      expect(recipes[:data]).to be_an(Array)
+      expect(recipes[:data]).to be_empty
+
+      expect(recipes).to_not have_key(:id)
+      expect(recipes).to_not have_key(:type)
+      expect(recipes).to_not have_key(:attributes)
+    end
   end
 end

--- a/spec/services/country_service_spec.rb
+++ b/spec/services/country_service_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe CountryService, :vcr do
+  describe "can get all countries" do
+    it "all_countries" do
+      countries = CountryService.new.all_countries
+
+      expect(countries).to be_an(Array)
+      expect(countries.count).to eq(250)
+      expect(countries[0]).to be_a(Hash)
+      expect(countries[0]).to have_key(:name)
+      expect(countries[0][:name]).to be_a(Hash)
+      expect(countries[0][:name]).to have_key(:common)
+      expect(countries[0][:name][:common]).to be_a(String)
+    end
+  end
+end

--- a/spec/services/recipe_service_spec.rb
+++ b/spec/services/recipe_service_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe RecipeService, :vcr do
+  describe "can create a connection to the Edamam API" do
+    it "recipes(search)" do
+      recipes = RecipeService.new.recipes("japan")
+
+      expect(recipes).to be_a(Hash)
+      expect(recipes).to have_key(:from)
+      expect(recipes[:from]).to be_a(Integer)
+      expect(recipes).to have_key(:to)
+      expect(recipes[:to]).to be_a(Integer)
+      expect(recipes).to have_key(:count)
+      expect(recipes[:count]).to be_a(Integer)
+      expect(recipes).to have_key(:_links)
+      expect(recipes[:_links]).to be_a(Hash)
+      expect(recipes).to have_key(:hits)
+      expect(recipes[:hits]).to be_an(Array)
+    end
+  end
+end


### PR DESCRIPTION
This completes the "get '/api/v1/recipes?'" 
Includes sad path testing where if a user doesn't input a country to search, one will be randomly generated.
100% test coverage with simplecov
